### PR TITLE
Fetch `$kirby` object to avoid PHP errors

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -4,6 +4,12 @@
 // = Component Registery =
 // =======================
 
+$kirby = kirby();
+
+// =======================
+// = Component Registery =
+// =======================
+
 $kirby->set('template', 'blog', __DIR__ . '/templates/blog.php');
 $kirby->set('template', 'article', __DIR__ . '/templates/article.php');
 $kirby->set('blueprint', 'blog', __DIR__ . '/blueprints/blog.php');


### PR DESCRIPTION
Without this, accessing the panel displays:
> Fatal error: Uncaught Error: Call to a member function set() on null in site/plugins/blog/blog.php:13

Toolkit version: 2.2.3
Kirby version: 2.2.3
Panel version: 2.2.3